### PR TITLE
Add dependabot to automatically update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
It would be nice to keep this tool up to date with latest version of SQLFluff.

It looks like it deploys automatically on merge to `master` so just adding a dependabot config file will cause GitHub to scan your requirements files and auto raise a Pull Request when a new version of any of the dependencies (including SQLFluff itself) is available.

This will save the manual effort of remembering to do this and, providing all tests pass, you can merge away and it should auto deploy.