### PR TITLE
Add Flask Talisman Security Headers

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -31,6 +31,7 @@ __pycache__
 .pytest_cache/
 .tox/
 env/
+.venv/
 
 # other files not needed for deploy
 .github

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .pytest_cache/
 .tox/
 env/
+.venv/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-pytest==5.4.3
-black==19.10b0
-requests==2.25.1
+pytest==6.2.4
+black==21.7b0
+requests==2.26.0
 beautifulsoup4==4.9.3
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-sqlfluff==0.6.1
-Flask==1.1.2
-Flask_Limiter==1.3.1
-gevent==20.9.0
-greenlet==0.4.17
-python-dotenv==0.13.0
+sqlfluff==0.6.4
+Flask==2.0.1
+Flask_Limiter==1.4.0
+flask-talisman==0.8.1
+gevent==21.8.0
+greenlet==1.1.1
+python-dotenv==0.19.0
 -e .

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -2,6 +2,8 @@
 from flask import Flask, render_template, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_talisman import Talisman
+from . import csp
 
 limiter = Limiter(
     key_func=get_remote_address, default_limits=["2 per second", "1000 per day"]
@@ -17,6 +19,11 @@ def ip_whitelist():
 def create_app():
     """App factory."""
     app = Flask(__name__)
+    talisman = Talisman(
+        app,
+        content_security_policy=csp.csp,
+        content_security_policy_nonce_in=["script-src"],
+    )
 
     from . import config, routes
 

--- a/src/app/csp.py
+++ b/src/app/csp.py
@@ -1,0 +1,25 @@
+csp = {
+    "default-src": "'self'",
+    "style-src": [
+        "'self'",
+        "stackpath.bootstrapcdn.com",
+        "'unsafe-inline'",
+    ],
+    "script-src": [
+        "'self'",
+        "'strict-dynamic'",
+        "www.google-analytics.com",
+        "www.googletagmanager.com",
+        "cdnjs.cloudflare.com",
+        "cdn.jsdelivr.net",
+        "stackpath.bootstrapcdn.com",
+        "pagecdn.io",
+        "'unsafe-inline'",
+    ],
+    "font-src": ["'none'"],
+    "connect-src": ["'none'"],
+    "img-src": ["'self'", "data:"],
+    "frame-src": ["'none'"],
+    "object-src": ["'none'"],
+    "base-uri": ["'none'"],
+}

--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -2,8 +2,8 @@
 
 <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80719882-6"></script>
-    <script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80719882-6" nonce="{{ csp_nonce() }}"></script>
+    <script nonce="{{ csp_nonce() }}">
         window.dataLayer = window.dataLayer || [];
         function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());
@@ -12,16 +12,16 @@
     </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
-        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-        crossorigin="anonymous"></script>
+        crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
-        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous" nonce="{{ csp_nonce() }}">
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
         integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
-        crossorigin="anonymous"></script>
-    <script src="https://pagecdn.io/lib/ace/1.4.12/ace.js" type="text/javascript" charset="utf-8"></script>
+        crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>
+    <script src="https://pagecdn.io/lib/ace/1.4.12/ace.js" type="text/javascript" charset="utf-8" nonce="{{ csp_nonce() }}"></script>
 </head>
 
 <body>

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -69,7 +69,7 @@
 
 
 {% block scripts %}
-<script>
+<script nonce="{{ csp_nonce() }}">
     // hook up ACE editor to all textareas with data-editor attribute
     $(function () {
         $('textarea[data-editor]').each(function () {

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 def client():
     """Application fixture."""
     application = app.create_app()
+    application.debug = True
 
     with application.test_client() as cli:
         yield cli
@@ -46,7 +47,7 @@ def test_results_some_errors(client):
 
 def test_carriage_return_sql(client):
     """Test the splitlines fix.
-    
+
     If it doesn't work, we should have one extra fixed character per carriage return.
     """
     sql_encoded = sql_encode("select col \r\n \r\n \r\n from xyz")
@@ -58,3 +59,12 @@ def test_carriage_return_sql(client):
 
     # we should get an extra z in there if the carriage returns are not well handled.
     assert fixed_sql.count("z") == 1
+
+
+def test_security_headers(client):
+    """Test flask-talisman is setting the security headers"""
+    rv = client.get("/")
+    assert (
+        rv.headers["Content-Security-Policy"] != None
+        and rv.headers["X-Content-Type-Options"] == "nosniff"
+    )

--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -10,6 +10,10 @@ def test_wsgi_app():
     command = ["python", "-m", "app.wsgi", "--port=5000"]
     with subprocess.Popen(command) as proc:
         time.sleep(1)
-        resp = requests.get("http://localhost:5000")
-        resp.raise_for_status()
+        resp = requests.get("http://localhost:5000", allow_redirects=False)
         proc.kill()
+        # Check Flask Talisman is redirecting to https version
+        assert (
+            resp.status_code == 302
+            and resp.headers["location"] == "https://localhost:5000/"
+        )


### PR DESCRIPTION
This adds Flask Talisman - a Flask Security Library I help maintain.

Flask Talisman adds the following features:
- Auto redirecting to HTTPS - note this doesn't happen on development envs as you don't have an SSL/TLS certificate. It does happen in tests (where debug mode is not set) so have to override there.
- Add HSTS header to force HTTPS in future (again not in test)
- Add Content Security Policy. A strong defence against XSS which should probably be used on a site like this that takes user input and reflects it back.
- Misc other headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Permissions-Policy`, `Referrer-Policy`)

I also took the opportunity to upgrade all the dependencies at the same time.