### PR TITLE
feature/DE-1358 make SQLFluff online working

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -39,3 +39,5 @@ coverage.xml
 # other files not needed for deploy
 .github
 test/
+
+.idea/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -32,6 +32,7 @@ __pycache__
 .tox/
 env/
 .venv/
+venv/
 .coverage
 coverage.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ env/
 .venv/
 .coverage
 coverage.xml
+.idea/

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,4 @@
+service: sqlfluff
 runtime: python38
 instance_class: F1
 entrypoint: python -m app.wsgi --port 8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ flask-talisman==1.0.0
 gevent==21.12.0
 greenlet==1.1.2
 python-dotenv==0.20.0
+# https://stackoverflow.com/a/71653849
+Werkzeug==2.0.0
+jinja2==3.0.3
 -e .

--- a/src/app/.sqlfluff
+++ b/src/app/.sqlfluff
@@ -1,0 +1,122 @@
+# SQLFluff configuration, adapted from https://docs.sqlfluff.com/en/stable/configuration.html.
+# All rules can be found https://docs.sqlfluff.com/en/stable/rules.html.
+[sqlfluff]
+verbose = 0
+nocolor = False
+dialect = bigquery
+templater = jinja
+rules = None
+# Disable L029 (Keywords should not be used as identifiers) due to false alarm (version, type, comment, name).
+# Disable L032 (Found USING statement. Expected only ON statements).
+# Don't change column ordering in existing queries (L034).
+# Don't omit `ELSE NULL` in a case when statement (L035).
+# Don't remove unnecessary whitespace (L039) to allow manual alignment of aliases.
+# L039 should be removed after solving https://github.com/sqlfluff/sqlfluff/issues/1582.
+# Disable L059 (Unnecessary quoted identifier) due to templating of table names.
+exclude_rules = L029,L032,L034,L035,L039,L059
+recurse = 0
+output_line_length = 80
+runaway_limit = 10
+ignore_templated_areas = True
+encoding = autodetect
+# Comma separated list of file extensions to lint.
+
+# NB: This config will only apply in the root folder.
+sql_file_exts = .sql,.sql.j2,.dml,.ddl
+# The number of parallel processes to run.
+processes = 2
+# Ignore particular families of errors so that they don’t cause a failed run.
+ignore = parsing,templating
+
+[sqlfluff:indentation]
+indented_joins = False
+indented_using_on = True
+template_blocks_indent = True
+
+[sqlfluff:templater]
+unwrap_wrapped_queries = True
+
+[sqlfluff:templater:jinja]
+apply_dbt_builtins = True
+
+[sqlfluff:templater:jinja:macros]
+# Macros provided as builtins for dbt projects
+# Comment out all the following macros to not break `pip install`
+# dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
+# dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
+# dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
+# dbt_var = {% macro var(variable, default='') %}item{% endmacro %}
+# dbt_is_incremental = {% macro is_incremental() %}True{% endmacro %}
+
+# Some rules can be configured directly from the config common to other rules.
+[sqlfluff:rules]
+tab_space_size = 4
+max_line_length = 300
+indent_unit = space
+comma_style = leading
+allow_scalar = True
+single_table_references = consistent
+unquoted_identifiers_policy = all
+
+# Some rules have their own specific config.
+[sqlfluff:rules:L007]  # Operators should be before/after newlines
+operator_new_lines = after
+
+[sqlfluff:rules:L010]  # Keywords
+capitalisation_policy = upper
+
+[sqlfluff:rules:L011]  # Aliasing
+aliasing = explicit
+
+[sqlfluff:rules:L012]  # Aliasing
+aliasing = explicit
+
+[sqlfluff:rules:L014]  # Unquoted identifiers
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:L016]
+ignore_comment_lines = False
+
+[sqlfluff:rules:L028]
+force_enable = False
+
+[sqlfluff:rules:L029]  # Keyword identifiers
+unquoted_identifiers_policy = aliases
+quoted_identifiers_policy = none
+
+[sqlfluff:rules:L030]  # Function names
+extended_capitalisation_policy = upper
+
+[sqlfluff:rules:L031]
+force_enable = False
+
+[sqlfluff:rules:L038]
+select_clause_trailing_comma = forbid
+
+[sqlfluff:rules:L040]  # Null & Boolean Literals
+capitalisation_policy = upper
+
+[sqlfluff:rules:L042]
+# Forbidden subqueries in from clauses and join clauses.
+forbid_subquery_in = both
+
+[sqlfluff:rules:L047]  # Consistent syntax to count all rows.
+prefer_count_1 = False
+prefer_count_0 = False
+
+[sqlfluff:rules:L051]  # Join clauses should be fully qualified.
+fully_qualify_join_types = inner
+
+[sqlfluff:rules:L052]  # Statements must end with a semi-colon.
+# Not require it for the final statements.
+require_final_semicolon = False
+# Semi-colon should follow immediately.
+multiline_newline = False
+
+[sqlfluff:rules:L057]  # Special characters in identifiers
+unquoted_identifiers_policy = all
+quoted_identifiers_policy = none
+allow_space_in_identifier = False
+
+[sqlfluff:rules:L063]  # Inconsistent capitalisation of datatypes
+extended_capitalisation_policy = upper

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,8 +1,9 @@
 """Init the applicaiton."""
-from flask import Flask, render_template, request
+from flask import Flask, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_talisman import Talisman
+
 from . import csp
 
 limiter = Limiter(
@@ -37,6 +38,7 @@ def create_app():
             all_rules=config.VALID_RULES,
             all_dialects=config.VALID_DIALECTS,
             sqlfluff_version=config.SQLFLUFF_VERSION,
+            dialect=config.DEFAULT_DIALECT,
         )
 
     return app

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -7,3 +7,7 @@ VALID_DIALECTS = tuple(d.name for d in sqlfluff.list_dialects())
 
 # dict mapping string rule names to descriptions
 VALID_RULES = {r.code: r.description for r in sqlfluff.list_rules()}
+
+DEFAULT_DIALECT = "bigquery"
+
+CONFIG_PATH = "src/app/.sqlfluff"

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -4,6 +4,8 @@ import gzip
 from flask import Blueprint, redirect, render_template, request, url_for
 from sqlfluff.api import fix, lint
 
+from . import config
+
 bp = Blueprint("routes", __name__)
 
 
@@ -44,8 +46,8 @@ def fluff_results():
     sql = "\n".join(sql.splitlines()) + "\n"
 
     dialect = request.args["dialect"]
-    linted = lint(sql, dialect=dialect)
-    fixed_sql = fix(sql, dialect=dialect)
+    linted = lint(sql, dialect=dialect, config_path=config.CONFIG_PATH)
+    fixed_sql = fix(sql, dialect=dialect, config_path=config.CONFIG_PATH)
     return render_template(
         "index.html",
         results=True,

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -92,7 +92,7 @@
             editor.getSession().setMode("ace/mode/" + mode);
             editor.setTheme("ace/theme/chrome");
 
-            var maxLength = 3000;
+            var maxLength = 65535;
 
             // update character counter on keyup
             editor.textInput.getElement().onkeyup = function () {


### PR DESCRIPTION
This PR makes SQLFluff online readily deployable to our App Engine:
- It adds our SQLFluff config file from data_eng
- It sets BigQuery as the default dialect
- It changes the max query length from 3000 to 65535
- It fixes an issue caused by a newer version of Werkzeug