### PR TITLE
Remove GA tag

### DIFF
--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -1,16 +1,6 @@
 <!doctype html>
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-80719882-6" nonce="{{ csp_nonce() }}"></script>
-    <script nonce="{{ csp_nonce() }}">
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-
-        gtag('config', 'UA-80719882-6');
-    </script>
-
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
         integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"


### PR DESCRIPTION
This tag was a holdover from when the site was not "official" (i.e., running on my personal heroku).

No reason to be tracking people using the site!