### PR TITLE
Update gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - id: deploy
-      uses: google-github-actions/deploy-appengine@main
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v1'
       with:
-        credentials: ${{ secrets.GCP_SA_KEY }}
+        credentials_json: '${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_JSON }}'
+    - id: 'deploy'
+      uses: google-github-actions/deploy-appengine@v1
 
     # Quick HTTP test
     - id: test


### PR DESCRIPTION
Fixes the [broken deploy action](https://github.com/sqlfluff/sqlfluff-online/actions/workflows/deploy.yaml).

It broke because we did not pin the deploy action version, and authenticating via `credentials` had been deprecated. I made new service creds (`GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_JSON`) and modernized that setup. No idea if i did it right; we will have to see!

I also reduced the frequency of dependabot checks. Tox has been going nuts on releases since 4.x.