### PR TITLE
Update app to python 3.10

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install Dependencies
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ You can also submit a PR if you'd like! If viable, your submission should includ
 
 ## Developer Setup
 
-Set up a python (3.8) environment however you'd like. Install the developer requires to your python environment:
+Set up a python (3.10) environment however you'd like. Install the developer requires to your python environment:
 
 ```sh
 $ pip install -r requirements-dev.txt

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python310
 instance_class: F1
 entrypoint: python -m app.wsgi --port 8080
 automatic_scaling:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py38, cov-report
+envlist = cov-init, py310, cov-report
 
 [testenv]
 deps = -r requirements-dev.txt


### PR DESCRIPTION
Doing some app engine maintenence!

Google app engine will no longer [support python 3.8](https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#python) as of Oct 14 2024. We have time but this PR will set the repo up through Oct 4 _2026_.