### PR TITLE
Auto drop old app versions on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,13 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - id: 'auth'
+    - name: Authorize to Google Cloud
       uses: 'google-github-actions/auth@v1'
       with:
         credentials_json: '${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_JSON }}'
-    - id: 'deploy'
+
+    - name: Deploy to App Engine
+      id: deploy
       uses: google-github-actions/deploy-appengine@v1
 
-    # Quick HTTP test
-    - id: test
+    - name: cURL Test
+      run: curl "${{ steps.deploy.outputs.url }}"
+
+    - name: Set up Cloud SDK
+      uses: 'google-github-actions/setup-gcloud@v1'
+
+    - name: Delete Old App Versions
+      # delete all but latest 5 versions
+      run: |
+        gcloud app versions list \
+          --format="value(version.id)" \
+          --sort-by="~version.createTime" \
+          | tail -n +5 \
+          | xargs -r gcloud app versions delete --quiet
+
+    # make sure we didn't delete the current version
+    - name: cURL Test
       run: curl "${{ steps.deploy.outputs.url }}"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,6 +1,6 @@
 name: Lint and 100% Test Coverage
 
-on: [push, pull_request]
+on: push
 
 jobs:
   run:


### PR DESCRIPTION
Fixes #304

App engine stores 32 versions as a maximum; and each commit to master here will add one. Even the weekly dependabot PRs do this, so it doesn't take long to hit the limit.


THis adds a new step in the deploy action to delete all but the 5 newest versions. I keep 5 in case we want to roll back and because its basically free.