### PR TITLE
Add dockerfile

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,3 +37,26 @@ jobs:
     # make sure we didn't delete the current version
     - name: cURL Test
       run: curl "${{ steps.deploy.outputs.url }}"
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          cache-from: ghcr.io/${{ github.repository }}:latest
+          cache-to: type=inline
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -r requirements.txt
+
+
+CMD ["python", "-m", "app.wsgi"]


### PR DESCRIPTION
Add Dockerfile and image with GitHub Packages. 

You can deploy your own sqlfluff online with command for example (official image name will be `sqlfluff/sqlfluff-online`):

```bash
 $ docker run --rm -e FLASK_ENV=development -e PORT=8081 -p 8081:8081 ghcr.io/hexlet-components/sqlfluff-online:latest  
# Go open http://localhost:8081
```