### PR TITLE
Fix dialect selector

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -38,7 +38,7 @@ def create_app():
         """Inject arbitrary data into all templates."""
         return dict(
             all_rules=config.VALID_RULES,
-            all_dialects=config.VALID_DIALECTS,
+            all_dialects=list(config.VALID_DIALECTS.values()),
             sqlfluff_version=config.SQLFLUFF_VERSION,
         )
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -4,7 +4,7 @@ import sqlfluff
 
 SQLFLUFF_VERSION = sqlfluff.__version__
 
-VALID_DIALECTS = tuple(d.name for d in sqlfluff.list_dialects())
+VALID_DIALECTS = {d.label: d.name for d in sqlfluff.list_dialects()}
 
 # dict mapping string rule names to descriptions
 VALID_RULES = {r.code: r.description for r in sqlfluff.list_rules()}

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -3,6 +3,7 @@ import gzip
 
 from flask import Blueprint, redirect, render_template, request, url_for
 from sqlfluff.api import fix, lint
+from .config import VALID_DIALECTS
 
 bp = Blueprint("routes", __name__)
 
@@ -43,7 +44,15 @@ def fluff_results():
     sql = sql_decode(request.args["sql"]).strip()
     sql = "\n".join(sql.splitlines()) + "\n"
 
+    # dialect must be a dialect label for `load_raw_dialect`. VALID_DIALECTS is a
+    # dictionary of dialect labels to dialect names. If we have a name, we need to
+    # get the label.
     dialect = request.args["dialect"]
+    if dialect in VALID_DIALECTS.values():
+        dialect = next(
+            label for label, name in VALID_DIALECTS.items() if name == dialect
+        )
+
     try:
         linted = lint(sql, dialect=dialect)
         fixed_sql = fix(sql, dialect=dialect)

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -47,15 +47,22 @@ def fluff_results():
     # dialect must be a dialect label for `load_raw_dialect`. VALID_DIALECTS is a
     # dictionary of dialect labels to dialect names. If we have a name, we need to
     # get the label.
+    #
+    # However, the frontend logic runs on dialect names, so we need to convert the
+    # label back to a name for the frontend.
     dialect = request.args["dialect"]
     if dialect in VALID_DIALECTS.values():
-        dialect = next(
+        dialect_name = dialect
+        dialect_label = next(
             label for label, name in VALID_DIALECTS.items() if name == dialect
         )
+    else:
+        dialect_label = dialect
+        dialect_name = VALID_DIALECTS[dialect]
 
     try:
-        linted = lint(sql, dialect=dialect)
-        fixed_sql = fix(sql, dialect=dialect)
+        linted = lint(sql, dialect=dialect_label)
+        fixed_sql = fix(sql, dialect=dialect_label)
     except RuntimeError as e:
         linted = [
             {
@@ -70,7 +77,7 @@ def fluff_results():
         "index.html",
         results=True,
         sql=sql,
-        dialect=dialect,
+        dialect=dialect_name,
         lint_errors=linted,
         fixed_sql=fixed_sql,
     )

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -36,10 +36,15 @@ def test_post_redirect(client):
     assert rv.status_code == 302 and "/fluffed?sql" in rv.headers["location"]
 
 
-def test_results_no_errors(client):
-    """Test that the results is good to go when there is no error."""
+@pytest.mark.parametrize("dialect", ["sparksql", "Apache Spark SQL"])
+def test_results_no_errors(client, dialect):
+    """Test that the results is good to go when there is no error.
+    
+    Parameterized dialect asserts that either the formatted name or label can be used
+    as the dialect parameter.
+    """
     sql_encoded = sql_encode("select * from table")
-    rv = client.get("/fluffed", query_string=f"""dialect=ansi&sql={sql_encoded}""")
+    rv = client.get("/fluffed", query_string=f"""dialect={dialect}&sql={sql_encoded}""")
     html = rv.data.decode().lower()
     assert "sqlfluff online" in html
     assert "fixed sql" in html

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -39,7 +39,7 @@ def test_post_redirect(client):
 @pytest.mark.parametrize("dialect", ["sparksql", "Apache Spark SQL"])
 def test_results_no_errors(client, dialect):
     """Test that the results is good to go when there is no error.
-    
+
     Parameterized dialect asserts that either the formatted name or label can be used
     as the dialect parameter.
     """
@@ -49,6 +49,14 @@ def test_results_no_errors(client, dialect):
     assert "sqlfluff online" in html
     assert "fixed sql" in html
     assert "select * from table" in html
+
+    # Test that the dialect is correctly selected in the results page.
+    selected_dialect = (
+        BeautifulSoup(html, "html.parser")
+        .find("select", {"id": "sql_dialect"})
+        .find("option", {"selected": "selected"})
+    )
+    assert selected_dialect.text.strip() == "apache spark sql"
 
 
 def test_results_some_errors(client):


### PR DESCRIPTION
fixes #389 

I think there were changes introduced in https://github.com/sqlfluff/sqlfluff/pull/6153 which changed the behavior of `sqlfluff.list_dialects` via `dialect_readout`, in which each dialect object's name became the _formatted_  name: 

https://github.com/sqlfluff/sqlfluff/commit/2464d36c28a496012d6a2719b3c29483978e1407#diff-910b0d8394425a99e2c2a292887f1ac6a981341b51147a76cc7f1b79907ce933L89

This name gets passed directly to `sqlfluff.api.lint/fix` functions, which caused errors because those functions expect _labels_. So the site has effectively been down for a few weeks without me noticing!

This pr extends the dialects config variables such that we store a mapping of names to labels. Frontend users see only the names, which are mapped back to the label on the backend. HTTP get calls can use either the name or the label (mostly so that all the old tests continue to pass).

I added some tests that either can be used, and that the automatic dialect selector continues to work.