### PR TITLE
Enforce Character limit in API

### DIFF
--- a/.github/workflows/pull_request_tests.yaml
+++ b/.github/workflows/pull_request_tests.yaml
@@ -1,0 +1,22 @@
+name: Pull Request Tests
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run Test Suite
+        run: pytest -q

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -40,6 +40,7 @@ def create_app():
             all_rules=config.VALID_RULES,
             all_dialects=list(config.VALID_DIALECTS.values()),
             sqlfluff_version=config.SQLFLUFF_VERSION,
+            sql_char_limit=config.SQL_CHAR_LIMIT,
         )
 
     return app

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -4,6 +4,9 @@ import sqlfluff
 
 SQLFLUFF_VERSION = sqlfluff.__version__
 
+# Shared SQL character limit used by frontend and backend validation.
+SQL_CHAR_LIMIT = 3000
+
 VALID_DIALECTS = {d.label: d.name for d in sqlfluff.list_dialects()}
 
 # dict mapping string rule names to descriptions

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -1,11 +1,17 @@
 import base64
 import gzip
 
-from flask import Blueprint, redirect, render_template, request, url_for
+from flask import Blueprint, abort, redirect, render_template, request, url_for
 from sqlfluff.api import fix, lint
-from .config import VALID_DIALECTS
+from .config import SQL_CHAR_LIMIT, VALID_DIALECTS
 
 bp = Blueprint("routes", __name__)
+
+
+def enforce_sql_char_limit(sql: str) -> None:
+    """Abort the request if SQL exceeds the configured character limit."""
+    if len(sql) > SQL_CHAR_LIMIT:
+        abort(413, description=f"SQL payload exceeds {SQL_CHAR_LIMIT} characters")
 
 
 def sql_encode(data: str) -> str:
@@ -30,6 +36,7 @@ def home():
     # this encoding dance is to protect against the possibility of getting a very
     # long SQL string that breaks something in HTTP get.
     sql = request.form["sql"]
+    enforce_sql_char_limit(sql)
     dialect = request.form["dialect"]
     return redirect(
         url_for("routes.fluff_results", sql=sql_encode(sql), dialect=dialect)
@@ -42,6 +49,7 @@ def fluff_results():
     # we get carriage returns from the form somehow. so split on them and join via
     # regular newline. add a newline to avoid the annoying newline-at-end-of-file error.
     sql = sql_decode(request.args["sql"]).strip()
+    enforce_sql_char_limit(sql)
     sql = "\n".join(sql.splitlines()) + "\n"
 
     # dialect must be a dialect label for `load_raw_dialect`. VALID_DIALECTS is a

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -92,7 +92,7 @@
             editor.getSession().setMode("ace/mode/" + mode);
             editor.setTheme("ace/theme/chrome");
 
-            var maxLength = 3000;
+            var maxLength = {{ sql_char_limit }};
 
             // update character counter on keyup
             editor.textInput.getElement().onkeyup = function () {

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -2,6 +2,7 @@
 
 import app
 import pytest
+from app.config import SQL_CHAR_LIMIT
 from app.routes import sql_encode
 from bs4 import BeautifulSoup
 from unittest.mock import patch
@@ -25,6 +26,13 @@ def test_home(client):
     assert "fixed sql" not in html
 
 
+def test_home_contains_shared_sql_char_limit(client):
+    """Test that the frontend character limit is sourced from shared config."""
+    rv = client.get("/")
+    html = rv.data.decode()
+    assert f"var maxLength = {SQL_CHAR_LIMIT};" in html
+
+
 def test_post_redirect(client):
     """Test the redirect works."""
     rv = client.post(
@@ -34,6 +42,19 @@ def test_post_redirect(client):
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     assert rv.status_code == 302 and "/fluffed?sql" in rv.headers["location"]
+
+
+@patch("app.routes.sql_encode")
+def test_post_rejects_over_limit_sql(mock_sql_encode, client):
+    """Reject payloads that exceed the SQL character limit."""
+    rv = client.post(
+        "/",
+        data=dict(sql="x" * (SQL_CHAR_LIMIT + 1), dialect="ansi"),
+        follow_redirects=False,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert rv.status_code == 413
+    mock_sql_encode.assert_not_called()
 
 
 @pytest.mark.parametrize("dialect", ["sparksql", "Apache Spark SQL"])
@@ -69,6 +90,18 @@ def test_results_some_errors(client):
     assert "select * from table" in html
     assert "line / position" in html
     assert "1 / 10" in html  # position of the error
+
+
+@patch("app.routes.lint")
+@patch("app.routes.fix")
+def test_results_rejects_over_limit_sql(mock_fix, mock_lint, client):
+    """Reject over-limit SQL before lint or fix processing."""
+    sql_encoded = sql_encode("x" * (SQL_CHAR_LIMIT + 1))
+    rv = client.get("/fluffed", query_string=f"""dialect=ansi&sql={sql_encoded}""")
+
+    assert rv.status_code == 413
+    mock_lint.assert_not_called()
+    mock_fix.assert_not_called()
 
 
 def test_carriage_return_sql(client):


### PR DESCRIPTION
Adds PR tests, and enforces character limit on both frontend and backend.