### PR TITLE
Adopt sqlfluff-design shared styling

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        submodules: true
+
+    - name: Sync sqlfluff-design assets
+      run: scripts/design_sync.sh
+
     - name: Authorize to Google Cloud
       uses: 'google-github-actions/auth@v3'
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ env/
 .venv/
 .coverage
 coverage.xml
+
+# synced from vendor/sqlfluff-design via scripts/design_sync.sh
+src/app/static/sqlfluff-design/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/sqlfluff-design"]
+	path = vendor/sqlfluff-design
+	url = https://github.com/sqlfluff/sqlfluff-design.git

--- a/scripts/design_sync.sh
+++ b/scripts/design_sync.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copy the vendored sqlfluff-design static assets into Flask's static folder.
+# Run before local development and before deploy (see .github/workflows/deploy.yaml).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source="$repo_root/vendor/sqlfluff-design/static/sqlfluff-design"
+dest="$repo_root/src/app/static/sqlfluff-design"
+
+test -d "$source" || {
+  echo "error: $source not found — did you run 'git submodule update --init'?" >&2
+  exit 1
+}
+
+mkdir -p "$dest"
+rsync -a --delete "$source/" "$dest/"
+echo "synced sqlfluff-design assets to $dest"

--- a/src/app/csp.py
+++ b/src/app/csp.py
@@ -16,7 +16,7 @@ csp = {
         "pagecdn.io",
         "'unsafe-inline'",
     ],
-    "font-src": ["'none'"],
+    "font-src": ["'self'"],
     "connect-src": ["'none'"],
     "img-src": ["'self'", "data:"],
     "frame-src": ["'none'"],

--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -1,6 +1,22 @@
 <!doctype html>
+<html lang="en">
 
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#f7f8f8">
+    <title>SQLFluff Online</title>
+
+    <link rel="icon" href="{{ url_for('static', filename='sqlfluff-design/img/favicon.ico') }}" sizes="any">
+    <link rel="icon" href="{{ url_for('static', filename='sqlfluff-design/img/favicon-32x32.png') }}" sizes="32x32" type="image/png">
+    <link rel="icon" href="{{ url_for('static', filename='sqlfluff-design/img/favicon-16x16.png') }}" sizes="16x16" type="image/png">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='sqlfluff-design/img/apple-touch-icon.png') }}">
+
+    <script src="{{ url_for('static', filename='sqlfluff-design/js/theme.js') }}" nonce="{{ csp_nonce() }}"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='sqlfluff-design/css/tokens.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='sqlfluff-design/css/base.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='sqlfluff-design/css/components.css') }}">
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
         integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
@@ -12,90 +28,106 @@
         integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
         crossorigin="anonymous" nonce="{{ csp_nonce() }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js" type="text/javascript" charset="utf-8" nonce="{{ csp_nonce() }}"></script>
-</head>
 
-<body>
-
-    <!-- A two column layout -->
-    <div class="container">
-        <h1>&#127881 SQLFluff Online &#127881</h1>
-
-        <p>
-            <a href='https://github.com/sqlfluff/sqlfluff'>SQLFluff</a> is a SQL
-            formatter that is implemented in Python. You can use this app to format
-            one-off, adhoc sql that might not be worth saving to a file. Or you can use
-            it to see what SQLFluff thinks of your queries. It's up to you!
-        </p>
-
-        <p>
-            You can check out the source code for this application on GitHub
-            (<a href='https://github.com/sqlfluff/sqlfluff-online'>click</a>).
-        </p>
-
-        <p>
-            Paste your SQL and select your dialect. Hit that button and find your fixed
-            SQL with the associated linter errors. Enjoy, friends &#127773.
-        </p>
-
-        <hr>
-
-        <div class="row">
-            <!-- user input -->
-            <div class="col-sm">
-                {% block left %}{% endblock %}
-            </div>
-
-            <div class="col-sm">
-                {% block right %}{% endblock %}
-            </div>
-        </div>
-
-        <hr>
-
-        <button class="btn btn btn-outline-dark btn-block" type="button" data-toggle="collapse" data-target="#more_info"
-            aria-expanded="false" aria-controls="collapseExample">
-            Click me for more info on this app
-        </button>
-
-        <hr>
-
-        <div class="collapse" id=more_info>
-            <p>
-                SQLFluff is maintained by a group of <s>talented</s> attractive and
-                selfless people who are all driven by a common disdain for poorly
-                formatted SQL. If you like fluff's treatment of your queries, feel
-                encouraged to check out our group on
-                <a href='https://github.com/sqlfluff'>GitHub</a>!
-            </p>
-            <p>
-                This app runs on SQLFluff version {{sqlfluff_version}}, and applies all
-                rules in that version. Here is a list of them:
-            </p>
-
-            <table class="table table-sm">
-                <thead>
-                    <tr>
-                        <th scope="col">Rule</th>
-                        <th scope="col">Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-
-                    {% for code, description in all_rules.items() %}
-                    <tr>
-                        <th scope="row">{{code}}</th>
-                        <td>{{description}}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
-
-    <style>
+    <style nonce="{{ csp_nonce() }}">
+        /* Bootstrap's own bare-element rules are unlayered, so they beat
+           sqlfluff-base's layered rules for the same elements. Reassert the
+           tokens here. */
         body {
-            margin: 2em;
-            max-width: 1500px;
+            background: var(--sqlfluff-color-canvas);
+            color: var(--sqlfluff-color-text);
+            font-family: var(--sqlfluff-font-sans);
+        }
+
+        button,
+        input,
+        select,
+        textarea {
+            font-family: var(--sqlfluff-font-sans);
+        }
+
+        pre,
+        code,
+        #user_sql,
+        #fixedSQL {
+            font-family: var(--sqlfluff-font-mono);
+        }
+
+        /* Bootstrap hardcodes `pre` to its own near-black text colour,
+           independent of the .table colour it sits inside. */
+        pre {
+            color: inherit;
+        }
+
+        h1, h2, h3 {
+            font-weight: 700;
+            line-height: 1.2;
+            letter-spacing: 0;
+        }
+
+        h1 { font-size: 3rem; }
+        h2 { font-size: 1.75rem; }
+        h3 { font-size: 1.15rem; }
+
+        a {
+            color: var(--sqlfluff-color-accent);
+        }
+
+        a:hover {
+            color: var(--sqlfluff-color-accent-hover);
+        }
+
+        /* Bootstrap's table text/border colours are fixed, near-black
+           values, so they go near-invisible against the dark canvas. */
+        .table {
+            color: var(--sqlfluff-color-text);
+        }
+
+        .table th,
+        .table td {
+            border-color: var(--sqlfluff-color-border);
+        }
+
+        .table-hover tbody tr:hover {
+            color: var(--sqlfluff-color-text);
+            background-color: var(--sqlfluff-color-surface-muted);
+        }
+
+        /* Bootstrap's alert colour pairs are fixed pastels that wash out
+           against the dark canvas; reassert readable variants sharing the
+           same GitHub-dark-derived palette as the code tokens. */
+        html[data-theme="dark"] .alert-danger {
+            color: var(--sqlfluff-color-code-red);
+            background-color: rgba(255, 123, 114, 0.12);
+            border-color: rgba(255, 123, 114, 0.35);
+        }
+
+        html[data-theme="dark"] .alert-success {
+            color: #3fb950;
+            background-color: rgba(63, 185, 80, 0.12);
+            border-color: rgba(63, 185, 80, 0.35);
+        }
+
+        /* Give the SQL input/output boxes the same fixed-dark terminal
+           treatment used for code elsewhere in the SQLFluff brand, rather
+           than Bootstrap's white form-control. The Ace-backed input picks
+           up its own colours from its dark theme; this only strips
+           Bootstrap's chrome so the shared .sqlfluff-terminal frame shows
+           through. */
+        .sqlfluff-terminal .form-control {
+            background: transparent;
+            color: var(--sqlfluff-color-code-text);
+            border: 0;
+            border-radius: 0;
+            box-shadow: none;
+        }
+
+
+        /* btn-block switches these to display:block for full width; centre
+           the label since justify-content only applies to the flex layout
+           sqlfluff-button otherwise uses. */
+        .sqlfluff-button.btn-block {
+            text-align: center;
         }
 
         #counter-container {
@@ -105,7 +137,143 @@
         #counter {
             padding: .25rem .75rem;
         }
-
     </style>
+</head>
+
+<body>
+    <a class="sqlfluff-skip-link" href="#main-content">Skip to content</a>
+    <header class="sqlfluff-site-header" data-sqlfluff-nav>
+        <div class="sqlfluff-container sqlfluff-header-inner">
+            <a class="sqlfluff-brand" href="{{ url_for('routes.home') }}" aria-label="SQLFluff home">
+                <img src="{{ url_for('static', filename='sqlfluff-design/img/sqlfluff-wide.png') }}" alt="">
+            </a>
+            <button class="sqlfluff-nav-toggle" type="button" aria-expanded="false"
+                aria-controls="sqlfluff-global-nav" data-sqlfluff-nav-toggle>
+                <span class="sqlfluff-visually-hidden">Open navigation</span>
+                <span></span><span></span><span></span>
+            </button>
+            <nav id="sqlfluff-global-nav" class="sqlfluff-nav"
+                aria-label="Global navigation" data-sqlfluff-nav-menu>
+                <a href="{{ url_for('routes.home') }}" aria-current="page">Online</a>
+                <a href="https://docs.sqlfluff.com">Docs</a>
+                <a href="https://github.com/sqlfluff/sqlfluff-online">GitHub</a>
+                <div class="sqlfluff-theme-control">
+                    <span id="sqlfluff-theme-label" class="sqlfluff-visually-hidden">Colour theme</span>
+                    <div class="sqlfluff-theme-switcher" role="group"
+                        aria-labelledby="sqlfluff-theme-label">
+                        <button type="button" data-sqlfluff-theme-value="auto"
+                            aria-label="Use system theme" title="System theme" aria-pressed="false">
+                            <span class="sqlfluff-theme-icon sqlfluff-theme-icon-system" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" data-sqlfluff-theme-value="light"
+                            aria-label="Use light theme" title="Light theme" aria-pressed="false">
+                            <span class="sqlfluff-theme-icon sqlfluff-theme-icon-light" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" data-sqlfluff-theme-value="dark"
+                            aria-label="Use dark theme" title="Dark theme" aria-pressed="false">
+                            <span class="sqlfluff-theme-icon sqlfluff-theme-icon-dark" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                </div>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main-content" class="sqlfluff-main">
+        <div class="sqlfluff-container">
+            <h1>SQLFluff Online</h1>
+
+            <p>
+                <a href='https://github.com/sqlfluff/sqlfluff'>SQLFluff</a> is a SQL
+                formatter that is implemented in Python. You can use this app to format
+                one-off, adhoc sql that might not be worth saving to a file. Or you can use
+                it to see what SQLFluff thinks of your queries. It's up to you!
+            </p>
+
+            <p>
+                You can check out the source code for this application on GitHub
+                (<a href='https://github.com/sqlfluff/sqlfluff-online'>click</a>).
+            </p>
+
+            <p>
+                Paste your SQL and select your dialect. Hit that button and find your fixed
+                SQL with the associated linter errors. Enjoy, friends.
+            </p>
+
+            <hr>
+
+            <div class="row">
+                <!-- user input -->
+                <div class="col-sm">
+                    {% block left %}{% endblock %}
+                </div>
+
+                <div class="col-sm">
+                    {% block right %}{% endblock %}
+                </div>
+            </div>
+
+            <hr>
+
+            <button class="sqlfluff-button btn-block" type="button" data-toggle="collapse" data-target="#more_info"
+                aria-expanded="false" aria-controls="collapseExample">
+                Click me for more info on this app
+            </button>
+
+            <hr>
+
+            <div class="collapse" id=more_info>
+                <p>
+                    SQLFluff is maintained by a group of <s>talented</s> attractive and
+                    selfless people who are all driven by a common disdain for poorly
+                    formatted SQL. If you like fluff's treatment of your queries, feel
+                    encouraged to check out our group on
+                    <a href='https://github.com/sqlfluff'>GitHub</a>!
+                </p>
+                <p>
+                    This app runs on SQLFluff version {{sqlfluff_version}}, and applies all
+                    rules in that version. Here is a list of them:
+                </p>
+
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th scope="col">Rule</th>
+                            <th scope="col">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+
+                        {% for code, description in all_rules.items() %}
+                        <tr>
+                            <th scope="row">{{code}}</th>
+                            <td>{{description}}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+
+    <footer class="sqlfluff-site-footer">
+        <div class="sqlfluff-container">
+            <div class="sqlfluff-footer-grid">
+                <div>
+                    <p class="sqlfluff-footer-title">SQLFluff</p>
+                    <p class="sqlfluff-footer-copy">The SQL linter for humans.</p>
+                </div>
+                <nav class="sqlfluff-footer-links" aria-label="Project links">
+                    <a href="https://docs.sqlfluff.com">Documentation</a>
+                    <a href="https://github.com/sqlfluff/sqlfluff-online">GitHub source</a>
+                </nav>
+                <nav class="sqlfluff-footer-links" aria-label="Community links">
+                    <a href="https://github.com/sqlfluff">GitHub</a>
+                </nav>
+            </div>
+        </div>
+    </footer>
+
     {% block scripts %}{% endblock %}
 </body>
+</html>

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -3,8 +3,11 @@
 <h2>Your Terrible SQL</h2>
 <form action='{{url_for("routes.home")}}' method="post">
     <div class="form-group">
-        <textarea class="form-control text-monospace" name='sql' data-editor="sql" , id="user_sql"
-            rows="20">{{sql}}</textarea>
+        <div class="sqlfluff-terminal">
+            <div class="sqlfluff-terminal-header">input.sql</div>
+            <textarea class="form-control text-monospace" name='sql' data-editor="sql" id="user_sql"
+                rows="20">{{sql}}</textarea>
+        </div>
         <div id="counter-container">
             <small id="counter"></small>
         </div>
@@ -22,7 +25,7 @@
         </select>
     </div>
 
-    <button type="submit" class="btn btn-primary mb-2 btn-block" id="submitButton">Help me.</button>
+    <button type="submit" class="sqlfluff-button sqlfluff-button-primary btn-block mb-2" id="submitButton">Help me.</button>
 </form>
 {% endblock %}
 
@@ -30,7 +33,10 @@
 {% block right %}
 {% if results %}
 <h2>SQLFluff's Fixed SQL</h2>
-<textarea id=fixedSQL class="form-control text-monospace" rows="20" readonly>{{fixed_sql}}</textarea>
+<div class="sqlfluff-terminal">
+    <div class="sqlfluff-terminal-header">output.sql</div>
+    <textarea id=fixedSQL class="form-control text-monospace" data-editor="sql" rows="20" readonly>{{fixed_sql}}</textarea>
+</div>
 
 <hr>
 
@@ -90,7 +96,15 @@
             editor.renderer.setShowGutter(true);
             editor.getSession().setValue(textarea.val());
             editor.getSession().setMode("ace/mode/" + mode);
-            editor.setTheme("ace/theme/chrome");
+            editor.setTheme("ace/theme/tomorrow_night");
+
+            // read-only editors (the fixed-SQL output) are for display only:
+            // no character counter, length limit, or submit-sync wiring.
+            if (textarea.prop("readonly")) {
+                editor.setReadOnly(true);
+                editor.renderer.$cursorLayer.element.style.display = "none";
+                return;
+            }
 
             var maxLength = {{ sql_char_limit }};
 


### PR DESCRIPTION
Theme refresh for SQLFluff Online, also so that it's line with the main site. Adds light mode and dark mode. Actual functionality is unchanged.

Light mode:

<img width="1431" height="1263" alt="image" src="https://github.com/user-attachments/assets/043d3155-67d1-4c6f-ae72-e43985e12cd4" />

aaaaaaand now also DARK MODE 🎉 🌙 :

<img width="1431" height="1263" alt="image" src="https://github.com/user-attachments/assets/989fa284-e192-4cbd-8bd6-5a27544261eb" />


## Summary
- Vendors [sqlfluff-design](https://github.com/sqlfluff/sqlfluff-design) as a git submodule (pinned to `design-v0.1.0`) and adopts its full-chrome tier: shared header, nav, theme switcher (light/dark/auto), footer, tokens, typography (IBM Plex Sans), and favicons.
- Assets are synced into Flask's static folder via `scripts/design_sync.sh`; the deploy workflow now checks out submodules and runs the sync before deploying.
- Buttons and the SQL input/output boxes are restyled onto the shared component classes and the brand's terminal treatment (dark, fixed-theme code panels with header bars); the output box now also gets live syntax highlighting and line numbers via Ace, matching the input.
- Headings, links, tables, and alerts get small adapter overrides so Bootstrap's own unlayered CSS (which otherwise wins the cascade against the shared package's intentionally-layered "floor" rules) doesn't clobber the shared tokens — this was most visible as unreadable table text and washed-out alerts in dark mode.
- CSP `font-src` updated from `'none'` to `'self'` for the self-hosted webfonts.

## Test plan
- [x] Local Flask dev server smoke-tested with headless Chromium: light/dark/auto theme toggle, header/nav/footer render correctly
- [x] Full lint/fix flow exercised end-to-end (Ace editor → submit → fixed SQL + error table) with no console errors
- [x] Rules table, lint-errors table, and both alert states (success/danger) checked for readability in dark mode
- [x] Confirmed light mode is unaffected by the dark-mode-targeted fixes
- [ ] CI: submodule checkout + asset sync step in `deploy.yaml` (not exercised locally — first real run will be on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)